### PR TITLE
Change Zenodo links to universal DOI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4074115.svg)](https://doi.org/10.5281/zenodo.4074115)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4074114.svg)](https://doi.org/10.5281/zenodo.4074114)
 
 ![Test correctness of notebooks](https://github.com/drvinceknight/pfm/workflows/Test%20correctness%20of%20notebooks/badge.svg)
 

--- a/book/about-this-book/citing-this-book/main.md
+++ b/book/about-this-book/citing-this-book/main.md
@@ -15,4 +15,4 @@ kernelspec:
 # How to cite this book
 
 Archived versions of the book can be obtained at
-<https://zenodo.org/record/4074115>. Citation information can be found there.
+<https://zenodo.org/record/4074114>. Citation information can be found there.


### PR DESCRIPTION
The current links are fixed at the archive for version `v0.0.1`. By downgrading to [10.5281/zenodo.4074114](https://doi.org/10.5281/zenodo.4074114), the most recent version is always resolved.